### PR TITLE
PatchError stack traces (and some general maintenance)

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -1,28 +1,31 @@
 "use strict";
 
-var _prototypeProperties = function (child, staticProps, instanceProps) { if (staticProps) Object.defineProperties(child, staticProps); if (instanceProps) Object.defineProperties(child.prototype, instanceProps); };
+var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
 exports.isError = isError;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 
-var PatchError = exports.PatchError = (function (Error) {
+var PatchError = exports.PatchError = (function (_Error) {
   function PatchError() {
     _classCallCheck(this, PatchError);
 
-    if (Error != null) {
-      Error.apply(this, arguments);
+    if (_Error != null) {
+      _Error.apply(this, arguments);
     }
   }
 
-  _inherits(PatchError, Error);
+  _inherits(PatchError, _Error);
 
   return PatchError;
 })(Error);
 
-var InvalidOperationError = exports.InvalidOperationError = (function (PatchError) {
+var InvalidOperationError = exports.InvalidOperationError = (function (_PatchError) {
   function InvalidOperationError(op, reason) {
     _classCallCheck(this, InvalidOperationError);
 
@@ -31,22 +34,20 @@ var InvalidOperationError = exports.InvalidOperationError = (function (PatchErro
     this.reason = reason;
   }
 
-  _inherits(InvalidOperationError, PatchError);
+  _inherits(InvalidOperationError, _PatchError);
 
-  _prototypeProperties(InvalidOperationError, null, {
+  _createClass(InvalidOperationError, {
     toString: {
       value: function toString() {
         return "Invalid " + this.op + " operation: " + this.reason;
-      },
-      writable: true,
-      configurable: true
+      }
     }
   });
 
   return InvalidOperationError;
 })(PatchError);
 
-var PathNotFoundError = exports.PathNotFoundError = (function (PatchError) {
+var PathNotFoundError = exports.PathNotFoundError = (function (_PatchError2) {
   function PathNotFoundError(path) {
     _classCallCheck(this, PathNotFoundError);
 
@@ -54,22 +55,20 @@ var PathNotFoundError = exports.PathNotFoundError = (function (PatchError) {
     this.path = path;
   }
 
-  _inherits(PathNotFoundError, PatchError);
+  _inherits(PathNotFoundError, _PatchError2);
 
-  _prototypeProperties(PathNotFoundError, null, {
+  _createClass(PathNotFoundError, {
     toString: {
       value: function toString() {
         return "Path not found: " + this.path;
-      },
-      writable: true,
-      configurable: true
+      }
     }
   });
 
   return PathNotFoundError;
 })(PatchError);
 
-var TestFailError = exports.TestFailError = (function (PatchError) {
+var TestFailError = exports.TestFailError = (function (_PatchError3) {
   function TestFailError(path, expected, value) {
     _classCallCheck(this, TestFailError);
 
@@ -79,22 +78,20 @@ var TestFailError = exports.TestFailError = (function (PatchError) {
     this.value = value;
   }
 
-  _inherits(TestFailError, PatchError);
+  _inherits(TestFailError, _PatchError3);
 
-  _prototypeProperties(TestFailError, null, {
+  _createClass(TestFailError, {
     toString: {
       value: function toString() {
         return "Test failed: " + ("expected " + this.path + " ") + ("to be " + this.expected + ", ") + ("but got " + this.value);
-      },
-      writable: true,
-      configurable: true
+      }
     }
   });
 
   return TestFailError;
 })(PatchError);
 
-var PointerError = exports.PointerError = (function (PatchError) {
+var PointerError = exports.PointerError = (function (_PatchError4) {
   function PointerError(message) {
     _classCallCheck(this, PointerError);
 
@@ -102,7 +99,7 @@ var PointerError = exports.PointerError = (function (PatchError) {
     this.message = message;
   }
 
-  _inherits(PointerError, PatchError);
+  _inherits(PointerError, _PatchError4);
 
   return PointerError;
 })(PatchError);
@@ -110,7 +107,3 @@ var PointerError = exports.PointerError = (function (PatchError) {
 function isError(err) {
   return err instanceof PatchError;
 }
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,78 +1,86 @@
-"use strict";
+'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-var _inherits = function (subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
-
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
-
-exports.isError = isError;
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
-var PatchError = exports.PatchError = (function (_Error) {
-  function PatchError() {
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+exports.isError = isError;
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+
+var PatchError = (function (_Error) {
+  // Based on https://gist.github.com/daliwali/09ca19032ab192524dc6
+
+  function PatchError(message) {
     _classCallCheck(this, PatchError);
 
-    if (_Error != null) {
-      _Error.apply(this, arguments);
-    }
+    _get(Object.getPrototypeOf(PatchError.prototype), 'constructor', this).call(this);
+
+    if (Error.hasOwnProperty('captureStackTrace')) Error.captureStackTrace(this, this.constructor);else Object.defineProperty(this, 'stack', {
+      value: new Error().stack
+    });
+
+    Object.defineProperty(this, 'message', {
+      value: message
+    });
   }
 
   _inherits(PatchError, _Error);
 
+  _createClass(PatchError, [{
+    key: 'name',
+    get: function () {
+      return this.constructor.name;
+    }
+  }]);
+
   return PatchError;
 })(Error);
 
-var InvalidOperationError = exports.InvalidOperationError = (function (_PatchError) {
+exports.PatchError = PatchError;
+
+var InvalidOperationError = (function (_PatchError) {
   function InvalidOperationError(op, reason) {
     _classCallCheck(this, InvalidOperationError);
 
-    this.name = "InvalidOperationError";
+    _get(Object.getPrototypeOf(InvalidOperationError.prototype), 'constructor', this).call(this, 'Invalid ' + op + ' operation: ' + reason);
     this.op = op;
     this.reason = reason;
   }
 
   _inherits(InvalidOperationError, _PatchError);
 
-  _createClass(InvalidOperationError, {
-    toString: {
-      value: function toString() {
-        return "Invalid " + this.op + " operation: " + this.reason;
-      }
-    }
-  });
-
   return InvalidOperationError;
 })(PatchError);
 
-var PathNotFoundError = exports.PathNotFoundError = (function (_PatchError2) {
+exports.InvalidOperationError = InvalidOperationError;
+
+var PathNotFoundError = (function (_PatchError2) {
   function PathNotFoundError(path) {
     _classCallCheck(this, PathNotFoundError);
 
-    this.name = "PathNotFoundError";
+    _get(Object.getPrototypeOf(PathNotFoundError.prototype), 'constructor', this).call(this, 'Path not found: ' + path);
     this.path = path;
   }
 
   _inherits(PathNotFoundError, _PatchError2);
 
-  _createClass(PathNotFoundError, {
-    toString: {
-      value: function toString() {
-        return "Path not found: " + this.path;
-      }
-    }
-  });
-
   return PathNotFoundError;
 })(PatchError);
 
-var TestFailError = exports.TestFailError = (function (_PatchError3) {
+exports.PathNotFoundError = PathNotFoundError;
+
+var TestFailError = (function (_PatchError3) {
   function TestFailError(path, expected, value) {
     _classCallCheck(this, TestFailError);
 
-    this.name = "TestFailError";
+    _get(Object.getPrototypeOf(TestFailError.prototype), 'constructor', this).call(this, 'Test failed: expected ' + path + ' to be ' + expected + ', but got ' + value);
     this.path = path;
     this.expected = expected;
     this.value = value;
@@ -80,29 +88,24 @@ var TestFailError = exports.TestFailError = (function (_PatchError3) {
 
   _inherits(TestFailError, _PatchError3);
 
-  _createClass(TestFailError, {
-    toString: {
-      value: function toString() {
-        return "Test failed: " + ("expected " + this.path + " ") + ("to be " + this.expected + ", ") + ("but got " + this.value);
-      }
-    }
-  });
-
   return TestFailError;
 })(PatchError);
 
-var PointerError = exports.PointerError = (function (_PatchError4) {
+exports.TestFailError = TestFailError;
+
+var PointerError = (function (_PatchError4) {
   function PointerError(message) {
     _classCallCheck(this, PointerError);
 
-    this.name = "PointerError";
-    this.message = message;
+    _get(Object.getPrototypeOf(PointerError.prototype), 'constructor', this).call(this, message);
   }
 
   _inherits(PointerError, _PatchError4);
 
   return PointerError;
 })(PatchError);
+
+exports.PointerError = PointerError;
 
 function isError(err) {
   return err instanceof PatchError;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,34 @@
-"use strict";
+'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
 
-var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
 
-var patch = _interopRequire(require("./patch"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var parse = _interopRequire(require("./parse"));
+var _patch = require('./patch');
 
-var error = _interopRequireWildcard(require("./error"));
+var _patch2 = _interopRequireDefault(_patch);
+
+var _parse = require('./parse');
+
+var _parse2 = _interopRequireDefault(_parse);
+
+var _error = require('./error');
+
+var error = _interopRequireWildcard(_error);
 
 for (var key in error) {
   /* istanbul ignore else */
   if (Object.prototype.hasOwnProperty.call(error, key)) {
-    patch[key] = error[key];
+    _patch2['default'][key] = error[key];
   }
 }
 
-patch.Error = patch.PatchError;
-patch.parse = parse;
+_patch2['default'].Error = _patch2['default'].PatchError;
+_patch2['default'].parse = _parse2['default'];
 
-module.exports = patch;
+exports['default'] = _patch2['default'];
+module.exports = exports['default'];

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,25 +1,19 @@
-"use strict";
+'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = parse;
 
-/**
- * Parse and validate the patch operation.
- *
- * Converts `op.path` (and `op.from` if
- * available) to an array.
- *
- * @param {object} op
- * @param {Immutable} target
- * @returns {object} op
- */
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
 
-module.exports = parse;
+var _immutable = require('immutable');
 
-var Iterable = require("immutable").Iterable;
+var _error = require('./error');
 
-var error = _interopRequireWildcard(require("./error"));
+var error = _interopRequireWildcard(_error);
 
-var OPERATORS = ["add", "remove", "replace", "move", "copy", "test"];
+var OPERATORS = ['add', 'remove', 'replace', 'move', 'copy', 'test'];
 
 var hop = Object.prototype.hasOwnProperty;
 
@@ -32,7 +26,7 @@ var hop = Object.prototype.hasOwnProperty;
  */
 
 function unescape(token) {
-  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
 }
 
 /**
@@ -44,11 +38,11 @@ function unescape(token) {
  */
 
 function parsePointer(pointer) {
-  if (pointer === "") {
+  if (pointer === '') {
     return [];
   }
-  if (pointer.charAt(0) !== "/") {
-    throw new error.PointerError("Invalid JSON pointer: " + pointer);
+  if (pointer.charAt(0) !== '/') {
+    throw new error.PointerError('Invalid JSON pointer: ' + pointer);
   }
   return pointer.substring(1).split(/\//).map(unescape);
 }
@@ -67,10 +61,10 @@ function validatePath(path, target) {
   var len = path.length;
   var ref = target;
   for (; i < len; i++) {
-    if (Iterable.isIterable(ref)) {
+    if (_immutable.Iterable.isIterable(ref)) {
       ref = ref.getIn(path.slice(0, i));
-      if (Iterable.isIndexed(ref) && !validateIndexToken(path[i])) {
-        throw new error.PointerError("Invalid array index: " + path[i]);
+      if (_immutable.Iterable.isIndexed(ref) && !validateIndexToken(path[i])) {
+        throw new error.PointerError('Invalid array index: ' + path[i]);
       }
     }
   }
@@ -87,7 +81,7 @@ function validatePath(path, target) {
  */
 
 function validateIndexToken(token) {
-  return token === "-" || /^(?:0|(?:[1-9][0-9]*))$/.test(token);
+  return token === '-' || /^(?:0|(?:[1-9][0-9]*))$/.test(token);
 }
 
 /**
@@ -105,6 +99,18 @@ function clone(obj) {
   }
   return copy;
 }
+
+/**
+ * Parse and validate the patch operation.
+ *
+ * Converts `op.path` (and `op.from` if
+ * available) to an array.
+ *
+ * @param {object} op
+ * @param {Immutable} target
+ * @returns {object} op
+ */
+
 function parse(op, target) {
   if (OPERATORS.indexOf(op.op) !== -1) {
     op = clone(op);
@@ -114,10 +120,12 @@ function parse(op, target) {
     if (op.path != null) {
       op.path = parsePointer(op.path);
     } else {
-      throw new error.InvalidOperationError(op.op, "Operation object must have a \"path\" member");
+      throw new error.InvalidOperationError(op.op, 'Operation object must have a "path" member');
     }
     validatePath(op.from || op.path, target);
     return op;
   }
-  throw new error.InvalidOperationError("Operation object \"op\" member must be one of " + OPERATORS.join(", ") + " " + ("but got \"" + op.op + "\""));
+  throw new error.InvalidOperationError('Operation object "op" member must be one of ' + OPERATORS.join(', ') + ' ' + ('but got "' + op.op + '"'));
 }
+
+module.exports = exports['default'];

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,37 +1,39 @@
-"use strict";
+'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { "default": obj }; };
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = patch;
 
-var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
 
-/**
- * Update the immutable object using JSON Patch
- * operations.
- *
- * @param {object} object
- * @param {array|object} ops
- * @returns {object}
- */
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-module.exports = patch;
+var _immutable = require('immutable');
 
-var Immutable = _interopRequire(require("immutable"));
+var _immutable2 = _interopRequireDefault(_immutable);
 
-var debug = _interopRequire(require("debug"));
+var _debug = require('debug');
 
-var parse = _interopRequire(require("./parse"));
+var _debug2 = _interopRequireDefault(_debug);
 
-var error = _interopRequireWildcard(require("./error"));
+var _parse = require('./parse');
 
-var Iterable = Immutable.Iterable;
+var _parse2 = _interopRequireDefault(_parse);
 
-debug = debug("immpatch");
+var _error = require('./error');
+
+var error = _interopRequireWildcard(_error);
+
+var Iterable = _immutable2['default'].Iterable;
+
+var debug = (0, _debug2['default'])('immpatch');
 
 var operators = {
 
   add: function add(op) {
-    if (typeof op.value === "undefined") {
-      throw new error.InvalidOperationError("add", "Operation object must have a \"value\" member");
+    if (typeof op.value === 'undefined') {
+      throw new error.InvalidOperationError('add', 'Operation object must have a "value" member');
     }
     var container, idx;
     var path = op.path;
@@ -55,13 +57,13 @@ var operators = {
         // array bounds, or it is '-', which
         // indicates that the value is to be appended
         idx = path[path.length - 1];
-        if (idx === "-") {
+        if (idx === '-') {
           return this.updateIn(parent, function (coll) {
             return coll.push(value);
           });
         }
         if (idx >= 0 && idx <= container.size) {
-          debug("add array element");
+          debug('add array element');
           return this.updateIn(parent, function (coll) {
             return coll.splice(idx, 0, value);
           });
@@ -78,11 +80,11 @@ var operators = {
     //
     // (1) is root doc    or (2) container is an object
     if (path.length === 0 || Iterable.isKeyed(container)) {
-      debug("add object member");
+      debug('add object member');
       return this.setIn(path, value);
     }
     // otherwise, it must be considered an error
-    throw new error.InvalidOperationError("add", "Target location must reference the root document or an existing object");
+    throw new error.InvalidOperationError('add', 'Target location must reference the root document or an existing object');
   },
 
   remove: function remove(op) {
@@ -93,8 +95,8 @@ var operators = {
   },
 
   replace: function replace(op) {
-    if (typeof op.value === "undefined") {
-      throw new error.InvalidOperationError("replace", "Operation object must have a \"value\" member");
+    if (typeof op.value === 'undefined') {
+      throw new error.InvalidOperationError('replace', 'Operation object must have a "value" member');
     }
     if (!this.hasIn(op.path)) {
       throw new error.PathNotFoundError(op.path);
@@ -104,7 +106,7 @@ var operators = {
 
   move: function move(op) {
     if (op.from == null) {
-      throw new error.InvalidOperationError("move", "Operation object must have a \"from\" member");
+      throw new error.InvalidOperationError('move', 'Operation object must have a "from" member');
     }
     if (!this.hasIn(op.from)) {
       throw new error.PathNotFoundError(op.from);
@@ -114,7 +116,7 @@ var operators = {
     var value = this.getIn(from);
     var target = this.getIn(path);
     if (Iterable.isIterable(target) && target.isSubset(value)) {
-      throw new error.InvalidOperationError("move", "\"from\" location cannot be moved into it's child");
+      throw new error.InvalidOperationError('move', '"from" location cannot be moved into it\'s child');
     }
     // this operation is functionally identical to a "remove"
     // operation on the "from" location, followed immediately
@@ -126,7 +128,7 @@ var operators = {
 
   copy: function copy(op) {
     if (op.from == null) {
-      throw new error.InvalidOperationError("copy", "Operation object must have a \"from\" member");
+      throw new error.InvalidOperationError('copy', 'Operation object must have a "from" member');
     }
     if (!this.hasIn(op.from)) {
       throw new error.PathNotFoundError(op.from);
@@ -141,29 +143,41 @@ var operators = {
   },
 
   test: function test(op) {
-    if (typeof op.value === "undefined") {
-      throw new error.InvalidOperationError("test", "Operation object must have a \"value\" member");
+    if (typeof op.value === 'undefined') {
+      throw new error.InvalidOperationError('test', 'Operation object must have a "value" member');
     }
     var path = op.path;
     var value = op.value;
     var target = this.getIn(path);
     // Use Immutable.is for testing, as what the specification
     // describes is essentially a recursive/deep equality check
-    if (!Immutable.is(target, Immutable.fromJS(value))) {
+    if (!_immutable2['default'].is(target, _immutable2['default'].fromJS(value))) {
       throw new error.TestFailError(path, value, target);
     }
     return this;
   }
 
 };
+
+/**
+ * Update the immutable object using JSON Patch
+ * operations.
+ *
+ * @param {object} object
+ * @param {array|object} ops
+ * @returns {object}
+ */
+
 function patch(object, ops) {
   ops = Array.isArray(ops) ? ops : [ops];
   object = ops.reduce(function (ob, op) {
-    op = parse(op, ob);
+    op = (0, _parse2['default'])(op, ob);
     return operators[op.op].call(ob, op);
   }, object);
   // Re-convert the returned object into an
   // immutable structure, in case the entire
   // object was replaced with a POJO
-  return Immutable.fromJS(object);
+  return _immutable2['default'].fromJS(object);
 }
+
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -36,18 +36,18 @@
     "npm": ">= 2.0.0"
   },
   "dependencies": {
-    "debug": "^2.1.1",
-    "immutable": "^3.6.2"
+    "debug": "^2.2.0",
+    "immutable": "^3.7.3"
   },
   "devDependencies": {
-    "babel": "^4.6.5",
-    "chai": "^1.10.0",
+    "babel": "^5.5.6",
+    "chai": "^3.0.0",
     "coveralls": "^2.11.2",
-    "istanbul": "^0.3.5",
-    "jiff": "^0.7.0",
-    "jshint": "^2.5.11",
-    "jshint-stylish": "^1.0.0",
-    "mocha": "^2.1.0",
-    "rimraf": "^2.2.8"
+    "istanbul": "^0.3.15",
+    "jiff": "^0.7.2",
+    "jshint": "^2.8.0",
+    "jshint-stylish": "^2.0.0",
+    "mocha": "^2.2.5",
+    "rimraf": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git://github.com/zaim/immpatch.git"
   },
   "scripts": {
-    "lint": "jshint --reporter node_modules/jshint-stylish/stylish src test",
+    "lint": "jshint --reporter node_modules/jshint-stylish src test",
     "compile": "rimraf lib && babel src --out-dir lib",
     "precompile": "npm run lint",
     "test": "mocha",

--- a/src/error.js
+++ b/src/error.js
@@ -1,52 +1,56 @@
-export class PatchError extends Error {}
+export class PatchError extends Error {
+  // Based on https://gist.github.com/daliwali/09ca19032ab192524dc6
+  constructor (message) {
+    super();
+ 
+    if (Error.hasOwnProperty('captureStackTrace'))
+      Error.captureStackTrace(this, this.constructor);
+    else
+      Object.defineProperty(this, 'stack', {
+        value: (new Error()).stack
+      });
+ 
+    Object.defineProperty(this, 'message', {
+      value: message
+    });
+  }
+ 
+  get name () {
+    return this.constructor.name;
+  }
+}
 
 
 export class InvalidOperationError extends PatchError {
   constructor (op, reason) {
-    this.name = 'InvalidOperationError'
+    super(`Invalid ${op} operation: ${reason}`)
     this.op = op
     this.reason = reason
-  }
-
-  toString () {
-    return `Invalid ${this.op} operation: ${this.reason}`
   }
 }
 
 
 export class PathNotFoundError extends PatchError {
   constructor (path) {
-    this.name = 'PathNotFoundError'
+    super(`Path not found: ${path}`)
     this.path = path
-  }
-
-  toString () {
-    return `Path not found: ${this.path}`
   }
 }
 
 
 export class TestFailError extends PatchError {
   constructor (path, expected, value) {
-    this.name = 'TestFailError'
+    super(`Test failed: expected ${path} to be ${expected}, but got ${value}`)
     this.path = path
     this.expected = expected
     this.value = value
-  }
-
-  toString () {
-    return `Test failed: `
-    + `expected ${this.path} `
-    + `to be ${this.expected}, `
-    + `but got ${this.value}`
   }
 }
 
 
 export class PointerError extends PatchError {
   constructor (message) {
-    this.name = 'PointerError'
-    this.message = message
+    super(message)
   }
 }
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,11 +1,11 @@
 import Immutable from 'immutable'
-import debug from 'debug'
+import makeDebug from 'debug'
 import parse from './parse'
 import * as error from './error'
 
 var Iterable = Immutable.Iterable
 
-debug = debug('immpatch')
+const debug = makeDebug('immpatch')
 
 
 var operators = {

--- a/test/errors.js
+++ b/test/errors.js
@@ -14,10 +14,10 @@ describe('errors', function () {
     var err2 = new patch.PathNotFoundError('test');
     var err3 = new patch.TestFailError('test');
     var err4 = new patch.PointerError('test');
-    expect(patch.isError(err1)).to.be.true();
-    expect(patch.isError(err2)).to.be.true();
-    expect(patch.isError(err3)).to.be.true();
-    expect(patch.isError(err4)).to.be.true();
+    expect(patch.isError(err1)).to.be.true;
+    expect(patch.isError(err2)).to.be.true;
+    expect(patch.isError(err3)).to.be.true;
+    expect(patch.isError(err4)).to.be.true;
   });
 
   it('should throw an error when op is invalid', function () {


### PR DESCRIPTION
This PR enables stack traces from PatchErrors by inheriting from Error in a more idiomatic way (h/t @daliwali for this [gist](https://gist.github.com/daliwali/09ca19032ab192524dc6)), updates most dependencies in package.json, and updates [json-patch-tests](https://github.com/json-patch/json-patch-tests) as well.

Some minor errors stemming from dep updates been fixed (e.g. ES6 correctness issues that surfaced in updating from Babel 4.x to 5.x). All tests pass.

(@zaim, thank you for writing this module! I intend to use it a lot in a project.)
